### PR TITLE
download models

### DIFF
--- a/download-medium-arc.json
+++ b/download-medium-arc.json
@@ -1,0 +1,21 @@
+{
+  "run": [
+    {
+      "when": "{{!exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-medium')}}",
+      "method": "hf.download",
+      "params": {
+        "_": ["cocktailpeanut/stable-audio-3-medium"]
+      }
+    },
+    {
+      "when": "{{exists('cache/HF_HOME/hub/models--cocktailpeanut--stable-audio-3-medium') && !exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-medium')}}",
+      "method": "shell.run",
+      "params": {
+        "path": "cache/HF_HOME/hub",
+        "message": [
+          "node -e \"require('fs').renameSync('models--cocktailpeanut--stable-audio-3-medium','models--stabilityai--stable-audio-3-medium')\""
+        ]
+      }
+    }
+  ]
+}

--- a/download-medium-rf.json
+++ b/download-medium-rf.json
@@ -1,0 +1,21 @@
+{
+  "run": [
+    {
+      "when": "{{!exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-medium-base')}}",
+      "method": "hf.download",
+      "params": {
+        "_": ["cocktailpeanut/stable-audio-3-medium-base"]
+      }
+    },
+    {
+      "when": "{{exists('cache/HF_HOME/hub/models--cocktailpeanut--stable-audio-3-medium-base') && !exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-medium-base')}}",
+      "method": "shell.run",
+      "params": {
+        "path": "cache/HF_HOME/hub",
+        "message": [
+          "node -e \"require('fs').renameSync('models--cocktailpeanut--stable-audio-3-medium-base','models--stabilityai--stable-audio-3-medium-base')\""
+        ]
+      }
+    }
+  ]
+}

--- a/download-small-arc.json
+++ b/download-small-arc.json
@@ -1,0 +1,21 @@
+{
+  "run": [
+    {
+      "when": "{{!exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-small-music')}}",
+      "method": "hf.download",
+      "params": {
+        "_": ["cocktailpeanut/stable-audio-3-small-music"]
+      }
+    },
+    {
+      "when": "{{exists('cache/HF_HOME/hub/models--cocktailpeanut--stable-audio-3-small-music') && !exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-small-music')}}",
+      "method": "shell.run",
+      "params": {
+        "path": "cache/HF_HOME/hub",
+        "message": [
+          "node -e \"require('fs').renameSync('models--cocktailpeanut--stable-audio-3-small-music','models--stabilityai--stable-audio-3-small-music')\""
+        ]
+      }
+    }
+  ]
+}

--- a/download-small-rf.json
+++ b/download-small-rf.json
@@ -1,0 +1,21 @@
+{
+  "run": [
+    {
+      "when": "{{!exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-small-music-base')}}",
+      "method": "hf.download",
+      "params": {
+        "_": ["cocktailpeanut/stable-audio-3-small-music-base"]
+      }
+    },
+    {
+      "when": "{{exists('cache/HF_HOME/hub/models--cocktailpeanut--stable-audio-3-small-music-base') && !exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-small-music-base')}}",
+      "method": "shell.run",
+      "params": {
+        "path": "cache/HF_HOME/hub",
+        "message": [
+          "node -e \"require('fs').renameSync('models--cocktailpeanut--stable-audio-3-small-music-base','models--stabilityai--stable-audio-3-small-music-base')\""
+        ]
+      }
+    }
+  ]
+}

--- a/install.json
+++ b/install.json
@@ -7,44 +7,49 @@
       "when": "{{!exists('app')}}",
       "method": "shell.run",
       "params": {
-        "message": [
-          "git clone https://github.com/gantasmo/theDAW app"
-        ]
+        "message": ["git clone https://github.com/gantasmo/theDAW app"]
       }
     },
     {
       "method": "shell.run",
       "params": {
         "path": "app",
-        "message": [
-          "git submodule update --init --recursive"
-        ]
+        "message": ["git submodule update --init --recursive"]
       }
     },
     {
+      "when": "{{platform === 'linux'}}",
       "method": "shell.run",
       "params": {
         "message": [
-          "conda install -y -c conda-forge ffmpeg"
+          "conda install -y -c conda-forge c-compiler cxx-compiler make pkg-config"
         ]
       }
     },
     {
+      "when": "{{platform === 'darwin'}}",
       "method": "shell.run",
       "params": {
         "path": "app",
-        "message": [
-          "uv sync --group dev"
-        ]
+        "env": {
+          "CFLAGS": "-Wno-incompatible-function-pointer-types"
+        },
+        "message": ["uv sync --group dev"]
+      }
+    },
+    {
+      "when": "{{platform !== 'darwin'}}",
+      "method": "shell.run",
+      "params": {
+        "path": "app",
+        "message": ["uv sync --group dev"]
       }
     },
     {
       "method": "shell.run",
       "params": {
         "path": "app/frontend",
-        "message": [
-          "npm install"
-        ]
+        "message": ["npm install"]
       }
     },
     {
@@ -52,17 +57,47 @@
       "method": "shell.run",
       "params": {
         "path": "app",
-        "message": [
-          "git clone https://github.com/gantasmo/VJ-9000 vj"
-        ]
+        "message": ["git clone https://github.com/gantasmo/VJ-9000 vj"]
       }
     },
     {
       "method": "shell.run",
       "params": {
         "path": "app/vj",
+        "message": ["npm install"]
+      }
+    },
+    {
+      "when": "{{platform === 'darwin' && !exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-small-music')}}",
+      "method": "hf.download",
+      "params": {
+        "_": ["cocktailpeanut/stable-audio-3-small-music"]
+      }
+    },
+    {
+      "when": "{{platform === 'darwin' && exists('cache/HF_HOME/hub/models--cocktailpeanut--stable-audio-3-small-music') && !exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-small-music')}}",
+      "method": "shell.run",
+      "params": {
+        "path": "cache/HF_HOME/hub",
         "message": [
-          "npm install"
+          "node -e \"require('fs').renameSync('models--cocktailpeanut--stable-audio-3-small-music','models--stabilityai--stable-audio-3-small-music')\""
+        ]
+      }
+    },
+    {
+      "when": "{{platform !== 'darwin' && !exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-medium')}}",
+      "method": "hf.download",
+      "params": {
+        "_": ["cocktailpeanut/stable-audio-3-medium"]
+      }
+    },
+    {
+      "when": "{{platform !== 'darwin' && exists('cache/HF_HOME/hub/models--cocktailpeanut--stable-audio-3-medium') && !exists('cache/HF_HOME/hub/models--stabilityai--stable-audio-3-medium')}}",
+      "method": "shell.run",
+      "params": {
+        "path": "cache/HF_HOME/hub",
+        "message": [
+          "node -e \"require('fs').renameSync('models--cocktailpeanut--stable-audio-3-medium','models--stabilityai--stable-audio-3-medium')\""
         ]
       }
     }

--- a/pinokio.js
+++ b/pinokio.js
@@ -37,6 +37,20 @@ module.exports = {
     * 
     **********************************************************************************************/
     let installed = info.exists("app/.venv") && info.exists("app/frontend/node_modules")
+    let downloading = [
+      "download-small-arc.json",
+      "download-small-rf.json",
+      "download-medium-arc.json",
+      "download-medium-rf.json"
+    ]
+    let is_downloading = null
+    for(let item of downloading) {
+      let d = info.running(item)
+      if (d === true) {
+        is_downloading = item
+        break;
+      }
+    }
     let running = {
       install: info.running("install.json"),
       start: info.running("start.json"),
@@ -45,6 +59,7 @@ module.exports = {
     }
     if (running.install) {
       return [{
+        default: true,
         icon: "fa-solid fa-plug",
         text: "Installing",
         href: "install.json",
@@ -54,48 +69,79 @@ module.exports = {
         let local = info.local("start.json")
         if (local && local.url) {
           return [{
-            icon: "fa-solid fa-power-off",
-            text: "Server",
-            href: "start.json",
-          }, {
             default: true,
             icon: "fa-solid fa-rocket",
-            text: "Open App",
+            text: "Open Web UI",
             href: local.url,
+          }, {
+            icon: 'fa-solid fa-terminal',
+            text: "Server",
+            href: "start.json",
+          }]
+        } else {
+          return [{
+            default: true,
+            icon: 'fa-solid fa-terminal',
+            text: "Server",
+            href: "start.json",
           }]
         }
       } else if (running.update) {
         return [{
           default: true,
-          icon: "fa-solid fa-rocket",
+          icon: 'fa-solid fa-terminal',
           text: "Updating",
-          href: "update.js"
+          href: "update.js",
         }]
       } else if (running.reset) {
         return [{
           default: true,
-          icon: "fa-solid fa-rocket",
+          icon: 'fa-solid fa-terminal',
           text: "Resetting",
-          href: "reset.js"
+          href: "reset.js",
+		}]
+	  } else if (running.cache) {
+        return [{
+          default: true,
+          icon: 'fa-solid fa-terminal',
+          text: "Clearing Cache",
+          href: "delete-cache.js",
+        }]
+      } else if (running.link) {
+        return [{
+          default: true,
+          icon: 'fa-solid fa-terminal',
+          text: "Deduplicating",
+          href: "link.js",
         }]
       } else {
         return [{
+          default: true,
           icon: "fa-solid fa-power-off",
           text: "Start",
           href: "start.json",
         }, {
+          icon: "fa-solid fa-download",
+          text: "Download Models",
+          menu: [
+            { text: "Small (ARC)", icon: "fa-solid fa-download", href: "download-small-arc.json", mode: "refresh" },
+            { text: "Small (RF)", icon: "fa-solid fa-download", href: "download-small-rf.json", mode: "refresh" },
+            { text: "Medium (ARC)", icon: "fa-solid fa-download", href: "download-medium-arc.json", mode: "refresh" },
+            { text: "Medium (RF)", icon: "fa-solid fa-download", href: "download-medium-rf.json", mode: "refresh" },
+          ]
+        }, {
           icon: "fa-solid fa-rocket",
           text: "Update",
-          href: "update.js"
+          href: "update.js",
         }, {
           icon: "fa-solid fa-plug",
           text: "Install",
           href: "install.json",
         }, {
           icon: "fa-regular fa-circle-xmark",
-          text: "<div><strong>Reset</strong><div>Revert to pre-install state</div></div>",
+          text: "Reset",
           href: "reset.js",
-          confirm: "Are you sure you wish to reset the app?"
+          confirm: "Are you sure you wish to reset this app?",
         }]
       }
     } else {

--- a/reset.js
+++ b/reset.js
@@ -2,12 +2,7 @@ module.exports = {
   run: [{
     method: "fs.rm",
     params: {
-      path: "app/.venv"
-    }
-  }, {
-    method: "fs.rm",
-    params: {
-      path: "app/frontend/node_modules"
+      path: "app"
     }
   }]
 }

--- a/start.json
+++ b/start.json
@@ -6,7 +6,6 @@
       "params": {
         "path": "app",
         "env": {
-          "HF_HOME": "{{path.resolve(os.homedir(), '.cache', 'huggingface')}}"
         },
         "message": [
           "uv run uvicorn backend.server:app --port 8600"


### PR DESCRIPTION
- cross platform support
- automatically download non--gated models. small (arc) model (for Mac) and medium (arc) model for Linux and windows.
- use HF_HOME inn  the project cache folder
- add download menu for optional models
- display running scripts in the menu
- reset app folder in case cloning fails